### PR TITLE
Lab16 - Include appsettings in deployment

### DIFF
--- a/Instructions/Labs/AZ400_M09_L16_Monitoring_Application_Performance_with_Application_Insights.md
+++ b/Instructions/Labs/AZ400_M09_L16_Monitoring_Application_Performance_with_Application_Insights.md
@@ -192,6 +192,7 @@ In this task, you will add a YAML build definition to the existing project.
     - Validate **App Service Type** points to Web App on Windows.
     - in the **App Service name** dropdown list, select the name of the web app you deployed earlier in the lab (**az400eshoponweb...).
     - in the **Package or folder** text box, **update** the Default Value to `$(Build.ArtifactStagingDirectory)/**/Web.zip`.
+    - Expand **Application and Configuration Settings and add the value `-UseOnlyInMemoryDatabase true -ASPNETCORE_ENVIRONMENT Development`
 1. Confirm the settings from the Assistant pane by clicking the **Add** button.
 
     > **Note**: This will automatically add the deployment task to the YAML pipeline definition.
@@ -206,6 +207,7 @@ In this task, you will add a YAML build definition to the existing project.
             appType: 'webApp'
             WebAppName: 'az400eshoponWeb369825031'
             packageForLinux: '$(Build.ArtifactStagingDirectory)/**/Web.zip'
+            AppSettings: '-UseOnlyInMemoryDatabase true -ASPNETCORE_ENVIRONMENT Development'
     ```
 
     > **Note**: The **packageForLinux** parameter is misleading in the context of this lab, but it is valid for Windows or Linux.


### PR DESCRIPTION
Added UseMemory and Development settings to AzureRmWebAppDeployment@4 task

Lab16 - Include appsettings in deployment

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- This PR changes the AzureRmWebAppDeployment@4 deployment step to include an appsettings property to allow for the dotnet 8 deployments